### PR TITLE
Try to fix executing basicInvalidateCache which blocks UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@types/chai": "^4.1.7",
     "@types/graphql": "^14.2.3",
     "@types/mocha": "^5.2.7",
+    "@types/node": "^12.0.0",
+    "@types/double-ended-queue": "^2.1.7",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
     "apollo-cache-inmemory": "^1.6.3",
@@ -59,5 +61,8 @@
     "rollup-plugin-typescript2": "^0.21.2",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"
+  },
+  "dependencies": {
+    "double-ended-queue": "^2.1.0-0"
   }
 }


### PR DESCRIPTION
[Try to reduce execute time](https://github.com/Yuyz0112/smart-cache/commit/2b9ed02b6bedca212977b6b7ca1c0cf91b192cb0)  

尝试改进和减少 basicInvalidateCache 方法的执行时间，主要是减少一些遍历。同时辅助以 [Draft: TOWER-12971 Reduce unnecessary data query](http://gitlab.smartx.com/frontend/tower/-/merge_requests/16462) ，这个 MR 主要是减少一些虚拟机页面和创建虚拟机弹窗中没有必要的 query 和字段。但还有一些不太好改，比如创建虚拟机弹窗会 query 整个 tower 所有的 ContentLibraryImages 回来作为 ImageSelect 的source 数据用，而 df 上有 2k 多条 ContentLibraryImages 数据，然后 basicInvalidateCache 中这 2k 多条 * deletedKeys 的数量就很容易上几万、十几万，得后面看一下怎么改。

改进后有一些改善，但也不多。改进前，如果进入虚拟机页面，下一页到第四页，触发克隆虚拟机操作，apollo cache 中有 5k 条左右的数据， df 可能 deleteCache 整体执行时间需要 10s+ ，改进后大多数是 5-6s 。但整体的时间复杂度的没有改变，而且 UI 还是会卡顿。

<img width="1440" alt="截屏2024-07-22 17 27 28" src="https://github.com/user-attachments/assets/f4381946-50a4-4b9e-88ee-5305a8acf5c1">

<img width="1435" alt="截屏2024-07-22 17 28 01" src="https://github.com/user-attachments/assets/eab5ba75-00e3-47e8-a36e-ddbb96b43362">

[Check deletedKeys slice by slice](https://github.com/Yuyz0112/smart-cache/commit/ffa521a77e9ce17a83fa8962a7dcc2a75851d7ce)  

basicInvalidateCache 中主要耗时的是在下面这段代码，大量的遍历在这个 while block 和 checkValueFromAnyObject 的执行中发生。有八九成时间都消耗在这一块。所以把这块代码检查的 keysNeedToBeCheck 切成 100 个一片进行处理，setTimeout 0 异步执行，避免阻塞 UI。

