### PR TITLE
Create cacheKeyIdMap first before check deletedKeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ dist
 es
 lib
 build
+benchmark/**/*.js
+benchmark/**/*.d.ts
 
 typings

--- a/benchmark/fixture/schema.graphql
+++ b/benchmark/fixture/schema.graphql
@@ -1,0 +1,40 @@
+type Query {
+  getUser(id: String!): User!
+  getPosts(page: Int!): [Post!]!
+  fuzzy: [Fuzzy!]!
+  nested: Nested!
+  noId: NoId
+  emptyUsers: [User!]!
+  pureText: String
+}
+
+type Mutation {
+  deletePost(id: String!): String!
+}
+
+type User {
+  id: String!
+  posts: [Post!]!
+}
+
+type Post {
+  id: String!
+  title: String!
+}
+
+type Fuzzy {
+  id: String!
+  posts: String!
+  content: String!
+}
+
+type Nested {
+  id: String!
+  users: [User!]!
+  posts: [Post!]!
+  fuzzy: [Fuzzy!]!
+}
+
+type NoId {
+  content: String!
+}

--- a/benchmark/fixture/typeFieldMap.ts
+++ b/benchmark/fixture/typeFieldMap.ts
@@ -1,0 +1,47 @@
+
+export type TypeFieldMap = Map<
+  string,
+  { dependentTypes: Set<string>; dependentQueries: Set<string> }
+>;
+
+export const typeFieldMap: TypeFieldMap = new Map<
+  string,
+  { dependentTypes: Set<string>; dependentQueries: Set<string> }
+>([
+    
+    [
+      "User",
+      {
+        dependentTypes: new Set(["User","Nested"]),
+        dependentQueries: new Set(["getUser","nested","emptyUsers"])
+      }
+    ],
+    [
+      "Post",
+      {
+        dependentTypes: new Set(["Post","User","Nested"]),
+        dependentQueries: new Set(["getUser","getPosts","nested","emptyUsers"])
+      }
+    ],
+    [
+      "Fuzzy",
+      {
+        dependentTypes: new Set(["Fuzzy","Nested"]),
+        dependentQueries: new Set(["fuzzy","nested"])
+      }
+    ],
+    [
+      "Nested",
+      {
+        dependentTypes: new Set(["Nested"]),
+        dependentQueries: new Set(["nested"])
+      }
+    ],
+    [
+      "NoId",
+      {
+        dependentTypes: new Set(["NoId"]),
+        dependentQueries: new Set(["noId"])
+      }
+    ]
+]);

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -107,7 +107,8 @@ benchmark('deleteCache 10x data', {
   benchmarkFn: (done, { client, cacheData }) => {
     const typename = 'User'
     client.cache.restore(cacheData)
-    client.deleteCache({ typename }, { callback: done })
+    client.deleteCache({ typename })
+    done()
   },
 })
 
@@ -125,7 +126,8 @@ benchmark('deleteCache 100x data', {
   benchmarkFn: (done, { client, cacheData }) => {
     const typename = 'User'
     client.cache.restore(cacheData)
-    client.deleteCache({ typename }, { callback: done })
+    client.deleteCache({ typename })
+    done()
   },
 })
 
@@ -143,7 +145,8 @@ benchmark('deleteCache 500x data', {
   benchmarkFn: (done, { client, cacheData }) => {
     const typename = 'User'
     client.cache.restore(cacheData)
-    client.deleteCache({ typename }, { callback: done })
+    client.deleteCache({ typename })
+    done()
   },
 })
 
@@ -161,7 +164,8 @@ benchmark('deleteCache 1000x data', {
   benchmarkFn: (done, { client, cacheData }) => {
     const typename = 'User'
     client.cache.restore(cacheData)
-    client.deleteCache({ typename }, { callback: done })
+    client.deleteCache({ typename })
+    done()
   },
 })
 

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import * as Benchmark from 'benchmark'
+import { SchemaLink } from 'apollo-link-schema'
+import { makeExecutableSchema } from 'graphql-tools'
+import { ApolloClient } from 'apollo-client'
+import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory'
+import { patch } from '../src/index'
+import { typeFieldMap } from './fixture/typeFieldMap'
+import { generateFakeData } from './utils'
+
+const typeDefs = readFileSync(
+  join(__dirname, './fixture/schema.graphql'),
+  'utf8'
+)
+
+patch(ApolloClient, InMemoryCache)
+
+const getClientInstance = () => {
+  const link = new SchemaLink({
+    schema: makeExecutableSchema({
+      typeDefs,
+      resolvers: {},
+    }),
+  })
+
+  const cache = new InMemoryCache()
+  cache.setTypeFieldMap(typeFieldMap)
+  const client = new ApolloClient({
+    link,
+    cache,
+  })
+  return client
+}
+
+const suite = new Benchmark.Suite()
+
+const benchmark = (
+  description: string,
+  fns:
+    | {
+        benchmarkFn: (done: () => void) => void
+      }
+    | {
+        prepare: () => {
+          client: ApolloClient<NormalizedCacheObject>
+          cacheData: NormalizedCacheObject
+        }
+        benchmarkFn: (
+          done: () => void,
+          data: {
+            client: ApolloClient<NormalizedCacheObject>
+            cacheData: NormalizedCacheObject
+          }
+        ) => void
+      }
+) => {
+  const name = description
+  console.log('Adding benchmark: ', name)
+
+  if ('prepare' in fns) {
+    const { benchmarkFn, prepare } = fns
+    const client = prepare()
+    suite.add(name, {
+      defer: true,
+      fn: (deferred: any) => {
+        const done = () => {
+          deferred.resolve()
+        }
+        benchmarkFn(done, client)
+      },
+    })
+    return
+  }
+
+  const { benchmarkFn } = fns
+  suite.add(name, {
+    defer: true,
+    fn: (deferred: any) => {
+      const done = () => {
+        deferred.resolve()
+      }
+      benchmarkFn(done)
+    },
+  })
+}
+
+benchmark('baseline', {
+  benchmarkFn: (done: () => void) => {
+    let arr = Array.from({ length: 100 }, () => Math.random())
+    arr.sort()
+    done()
+  },
+})
+
+benchmark('deleteCache 10x data', {
+  prepare: () => {
+    const cacheData = generateFakeData(10)
+    const client = getClientInstance()
+    console.log(
+      `deleteCache 10x data: check keys count ${
+        Object.keys(cacheData).length
+      }\n`
+    )
+    return { client, cacheData }
+  },
+  benchmarkFn: (done, { client, cacheData }) => {
+    const typename = 'User'
+    client.cache.restore(cacheData)
+    client.deleteCache({ typename }, { callback: done })
+  },
+})
+
+benchmark('deleteCache 100x data', {
+  prepare: () => {
+    const cacheData = generateFakeData(100)
+    const client = getClientInstance()
+    console.log(
+      `deleteCache 100x data: check keys count ${
+        Object.keys(cacheData).length
+      }\n`
+    )
+    return { client, cacheData }
+  },
+  benchmarkFn: (done, { client, cacheData }) => {
+    const typename = 'User'
+    client.cache.restore(cacheData)
+    client.deleteCache({ typename }, { callback: done })
+  },
+})
+
+benchmark('deleteCache 500x data', {
+  prepare: () => {
+    const cacheData = generateFakeData(500)
+    const client = getClientInstance()
+    console.log(
+      `deleteCache 500x data: check keys count ${
+        Object.keys(cacheData).length
+      }\n`
+    )
+    return { client, cacheData }
+  },
+  benchmarkFn: (done, { client, cacheData }) => {
+    const typename = 'User'
+    client.cache.restore(cacheData)
+    client.deleteCache({ typename }, { callback: done })
+  },
+})
+
+benchmark('deleteCache 1000x data', {
+  prepare: () => {
+    const cacheData = generateFakeData(1000)
+    const client = getClientInstance()
+    console.log(
+      `deleteCache 1000x data: check keys count ${
+        Object.keys(cacheData).length
+      }\n`
+    )
+    return { client, cacheData }
+  },
+  benchmarkFn: (done, { client, cacheData }) => {
+    const typename = 'User'
+    client.cache.restore(cacheData)
+    client.deleteCache({ typename }, { callback: done })
+  },
+})
+
+suite
+  .on('error', (error: any) => {
+    console.log('Error: ', error)
+  })
+  .on('cycle', (event: any) => {
+    console.log('Mean time in ms: ', event.target.stats.mean * 1000)
+    console.log(String(event.target))
+    console.log('')
+  })
+  .run({ async: true })

--- a/benchmark/utils.ts
+++ b/benchmark/utils.ts
@@ -1,0 +1,128 @@
+import { NormalizedCacheObject } from 'apollo-cache-inmemory'
+import { ListValue } from 'apollo-utilities'
+
+export const generateFakeData = (size: number) => {
+  if (size < 1)
+    return {
+      ROOT_QUERY: {},
+    }
+
+  const data: NormalizedCacheObject = {
+    ROOT_QUERY: {
+      getNestedes: [],
+      getUsers: [],
+      getPosts: [],
+      getPost: { id: '1', title: 'Post 1', __typename: 'Post' },
+      getNested: {
+        type: 'id',
+        generated: false,
+        id: 'Nested:1',
+        typename: 'Nested',
+      },
+      getUser: {
+        type: 'id',
+        generated: false,
+        id: 'User:1',
+        typename: 'User',
+      },
+    },
+  }
+
+  const numbers = new Array(size).fill(null).map((_, i) => i + 1)
+  const rand = () => Math.random() * 10000;
+
+  numbers.forEach(n => {
+    const NestedId = rand();
+    const UserId = rand();
+    const PostId = rand();
+    const FuzzId = rand();
+
+    data[`Nested:${NestedId}`] = {
+      __typename: 'Nested',
+      prop1: 'prop1',
+      prop2: 'prop2',
+      prop3: 'prop3',
+      id: `${NestedId}`,
+      users: [
+        {
+          type: 'id',
+          generated: false,
+          id: `User:${UserId}`,
+          typename: 'User',
+        }
+      ],
+      posts: [
+        {
+          type: 'id',
+          generated: false,
+          id: `Post:${PostId}`,
+          typename: 'Post',
+        }
+      ],
+      fuzzy: [
+        {
+          type: 'id',
+          generated: false,
+          id: `Fuzzy:${FuzzId}`,
+          typename: 'Fuzzy',
+        }
+      ],
+    }
+
+    data[`User:${UserId}`] = {
+      __typename: 'User',
+      prop1: 'prop1',
+      prop2: 'prop2',
+      prop3: 'prop3',
+      id: `${UserId}`,
+      posts: [
+        {
+          type: 'id',
+          generated: false,
+          id: `Post:${PostId}`,
+          typename: 'Post',
+        }
+      ],
+    }
+
+    data[`Post:${PostId}`] = {
+      __typename: 'Post',
+      prop1: 'prop1',
+      prop2: 'prop2',
+      prop3: 'prop3',
+      id: `${PostId}`,
+      title: `Post ${PostId}`,
+    }
+
+    data[`Fuzzy:${FuzzId}`] = {
+      __typename: 'Fuzzy',
+      prop1: 'prop1',
+      prop2: 'prop2',
+      prop3: 'prop3',
+      id: `${FuzzId}`,
+      content: 'Post:1',
+      posts: 'fuzzy key',
+    }
+
+    ;(data.ROOT_QUERY?.getNestedes as ListValue)?.push({
+      type: 'id',
+      generated: false,
+      id: `Nested:${NestedId}`,
+      typename: 'Nested',
+    })
+    ;(data.ROOT_QUERY?.getUsers as ListValue)?.push({
+      type: 'id',
+      generated: false,
+      id: `User:${UserId}`,
+      typename: 'User',
+    })
+    ;(data.ROOT_QUERY?.getPosts as ListValue)?.push({
+      type: 'id',
+      generated: false,
+      id: `Post:${PostId}`,
+      typename: 'Post',
+    })
+  })
+
+  return data;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "tsc && rollup --config && cp build/codegen.js* lib/",
     "typings": "tsc -d --emitDeclarationOnly --declarationDir typings",
     "release": "release-it",
-    "test": "cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.spec.ts"
+    "test": "cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.spec.ts",
+    "benchmark": "cross-env TS_NODE_CACHE=false TS_NODE_FILES=true ts-node benchmark/index.ts"
   },
   "keywords": [
     "apollo-client",
@@ -37,16 +38,19 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
+    "@types/benchmark": "1.0.31",
+    "@types/double-ended-queue": "^2.1.7",
     "@types/graphql": "^14.2.3",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.0",
-    "@types/double-ended-queue": "^2.1.7",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
     "apollo-link-schema": "^1.2.3",
     "apollo-utilities": "^1.3.2",
+    "benchmark": "^2.1.4",
+    "double-ended-queue": "^2.1.0-0",
     "chai": "^4.2.0",
     "cross-env": "^5.2.0",
     "eslint": "^6.0.1",
@@ -61,8 +65,5 @@
     "rollup-plugin-typescript2": "^0.21.2",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"
-  },
-  "dependencies": {
-    "double-ended-queue": "^2.1.0-0"
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -109,366 +109,276 @@ describe('cache invalidation', () => {
     client.cache.reset()
   })
 
-  it('can delete an entity and corresponding queries', done => {
-    client
-      .query({
-        query: gql`
-          query {
-            getUser(id: "1") {
-              id
-              posts {
-                id
-                title
-              }
-            }
-          }
-        `,
-      })
-      .then(() => {
-        haveProps(client.cache.extract(), [
-          'ROOT_QUERY.getUser({"id":"1"})',
-          'User:1',
-          'Post:2',
-        ])
-        client.deleteCache(
-          {
-            typename: 'User',
-            value: {
-              __typename: 'User',
-              id: '1',
-            },
-          },
-          {
-            callback: () => {
-              haveProps(client.cache.extract(), ['Post:2'])
-              notHaveProps(client.cache.extract(), [
-                'ROOT_QUERY.getUser({"id":"1"})',
-                'User:1',
-              ])
-              done()
-            },
-          }
-        )
-      })
-  })
-
-  it('can delete an deep dependent entity and corresponding queries', done => {
-    client
-      .query({
-        query: gql`
-          query {
-            getUser(id: "1") {
-              id
-              posts {
-                id
-                title
-              }
-            }
-          }
-        `,
-      })
-      .then(() => {
-        haveProps(client.cache.extract(), [
-          'ROOT_QUERY.getUser({"id":"1"})',
-          'User:1',
-          'Post:2',
-        ])
-        client.deleteCache(
-          {
-            typename: 'Post',
-            value: {
-              __typename: 'Post',
-              id: '2',
-            },
-          },
-          {
-            callback: () => {
-              notHaveProps(client.cache.extract(), [
-                'ROOT_QUERY.getUser({"id":"1"})',
-                'User:1',
-                'Post:2',
-              ])
-              done()
-            },
-          }
-        )
-      })
-  })
-
-  it('can delete pagination data when any dependent entity was removed', done => {
-    client
-      .query({
-        query: gql`
-          query {
-            getPosts(page: 1) {
+  it('can delete an entity and corresponding queries', async () => {
+    await client.query({
+      query: gql`
+        query {
+          getUser(id: "1") {
+            id
+            posts {
               id
               title
             }
           }
-        `,
-      })
-      .then(() =>
-        client.query({
-          query: gql`
-            query {
-              getPosts(page: 2) {
-                id
-                title
-              }
-            }
-          `,
-        })
-      )
-      .then(() => {
-        haveProps(client.cache.extract(), [
-          'ROOT_QUERY.getPosts({"page":1})',
-          'ROOT_QUERY.getPosts({"page":2})',
-          'Post:1',
-          'Post:2',
-        ])
-        client.deleteCache(
-          {
-            typename: 'Post',
-            value: { __typename: 'Post', id: '2' },
-          },
-          {
-            callback: () => {
-              haveProps(client.cache.extract(), ['Post:1'])
-              notHaveProps(client.cache.extract(), [
-                'ROOT_QUERY.getPosts({"page":1})',
-                'ROOT_QUERY.getPosts({"page":2})',
-                'Post:2',
-              ])
-              done()
-            },
-          }
-        )
-      })
+        }
+      `,
+    })
+    haveProps(client.cache.extract(), [
+      'ROOT_QUERY.getUser({"id":"1"})',
+      'User:1',
+      'Post:2',
+    ])
+    client.deleteCache({
+      typename: 'User',
+      value: {
+        __typename: 'User',
+        id: '1',
+      },
+    })
+    haveProps(client.cache.extract(), ['Post:2'])
+    notHaveProps(client.cache.extract(), [
+      'ROOT_QUERY.getUser({"id":"1"})',
+      'User:1',
+    ])
   })
 
-  it('can delete a type of entities and there corresponding queries', done => {
-    client
-      .query({
-        query: gql`
-          query {
-            getUser(id: "1") {
+  it('can delete an deep dependent entity and corresponding queries', async () => {
+    await client.query({
+      query: gql`
+        query {
+          getUser(id: "1") {
+            id
+            posts {
+              id
+              title
+            }
+          }
+        }
+      `,
+    })
+    haveProps(client.cache.extract(), [
+      'ROOT_QUERY.getUser({"id":"1"})',
+      'User:1',
+      'Post:2',
+    ])
+    client.deleteCache({
+      typename: 'Post',
+      value: {
+        __typename: 'Post',
+        id: '2',
+      },
+    })
+    notHaveProps(client.cache.extract(), [
+      'ROOT_QUERY.getUser({"id":"1"})',
+      'User:1',
+      'Post:2',
+    ])
+  })
+
+  it('can delete pagination data when any dependent entity was removed', async () => {
+    await client.query({
+      query: gql`
+        query {
+          getPosts(page: 1) {
+            id
+            title
+          }
+        }
+      `,
+    })
+    await client.query({
+      query: gql`
+        query {
+          getPosts(page: 2) {
+            id
+            title
+          }
+        }
+      `,
+    })
+    haveProps(client.cache.extract(), [
+      'ROOT_QUERY.getPosts({"page":1})',
+      'ROOT_QUERY.getPosts({"page":2})',
+      'Post:1',
+      'Post:2',
+    ])
+    client.deleteCache({
+      typename: 'Post',
+      value: { __typename: 'Post', id: '2' },
+    })
+    haveProps(client.cache.extract(), ['Post:1'])
+    notHaveProps(client.cache.extract(), [
+      'ROOT_QUERY.getPosts({"page":1})',
+      'ROOT_QUERY.getPosts({"page":2})',
+      'Post:2',
+    ])
+  })
+
+  it('can delete a type of entities and there corresponding queries', async () => {
+    await client.query({
+      query: gql`
+        query {
+          getUser(id: "1") {
+            id
+            posts {
+              id
+              title
+            }
+          }
+        }
+      `,
+    })
+    await client.query({
+      query: gql`
+        query {
+          getPosts(page: 1) {
+            id
+            title
+          }
+        }
+      `,
+    })
+    await client.query({
+      query: gql`
+        query {
+          getPosts(page: 2) {
+            id
+            title
+          }
+        }
+      `,
+    })
+    haveProps(client.cache.extract(), [
+      'ROOT_QUERY.getUser({"id":"1"})',
+      'ROOT_QUERY.getPosts({"page":1})',
+      'ROOT_QUERY.getPosts({"page":2})',
+      'User:1',
+      'Post:1',
+      'Post:2',
+    ])
+    client.deleteCache({ typename: 'Post' })
+    notHaveProps(client.cache.extract(), [
+      'ROOT_QUERY.getUser({"id":"1"})',
+      'ROOT_QUERY.getPosts({"page":1})',
+      'ROOT_QUERY.getPosts({"page":2})',
+      'User:1',
+      'Post:1',
+      'Post:2',
+    ])
+  })
+
+  it('should not match field value', async () => {
+    await client.query({
+      query: gql`
+        query {
+          fuzzy {
+            id
+            posts
+            content
+          }
+        }
+      `,
+    })
+    await client.query({
+      query: gql`
+        query {
+          getPosts(page: 1) {
+            id
+            title
+          }
+        }
+      `,
+    })
+    haveProps(client.cache.extract(), [
+      'ROOT_QUERY.fuzzy',
+      'ROOT_QUERY.getPosts({"page":1})',
+      'Fuzzy:1',
+      'Post:1',
+    ])
+    client.deleteCache({ typename: 'Post' })
+    haveProps(client.cache.extract(), ['ROOT_QUERY.fuzzy', 'Fuzzy:1'])
+    notHaveProps(client.cache.extract(), [
+      'ROOT_QUERY.getPosts({"page":1})',
+      'Post:1',
+    ])
+  })
+
+  it('handle nested value', async () => {
+    await client.query({
+      query: gql`
+        query {
+          nested {
+            id
+            users {
               id
               posts {
                 id
                 title
               }
             }
-          }
-        `,
-      })
-      .then(() => {
-        client.query({
-          query: gql`
-            query {
-              getPosts(page: 1) {
-                id
-                title
-              }
+            posts {
+              id
+              title
             }
-          `,
-        })
-      })
-      .then(() => {
-        client.query({
-          query: gql`
-            query {
-              getPosts(page: 2) {
-                id
-                title
-              }
-            }
-          `,
-        })
-      })
-      .then(() => {
-        haveProps(client.cache.extract(), [
-          'ROOT_QUERY.getUser({"id":"1"})',
-          'ROOT_QUERY.getPosts({"page":1})',
-          'ROOT_QUERY.getPosts({"page":2})',
-          'User:1',
-          'Post:1',
-          'Post:2',
-        ])
-        client.deleteCache(
-          { typename: 'Post' },
-          {
-            callback: () => {
-              notHaveProps(client.cache.extract(), [
-                'ROOT_QUERY.getUser({"id":"1"})',
-                'ROOT_QUERY.getPosts({"page":1})',
-                'ROOT_QUERY.getPosts({"page":2})',
-                'User:1',
-                'Post:1',
-                'Post:2',
-              ])
-              done()
-            },
-          }
-        )
-      })
-  })
-
-  it('should not match field value', done => {
-    client
-      .query({
-        query: gql`
-          query {
             fuzzy {
               id
               posts
               content
             }
           }
-        `,
-      })
-      .then(() => {
-        client.query({
-          query: gql`
-            query {
-              getPosts(page: 1) {
-                id
-                title
-              }
-            }
-          `,
-        })
-      })
-      .then(() => {
-        haveProps(client.cache.extract(), [
-          'ROOT_QUERY.fuzzy',
-          'ROOT_QUERY.getPosts({"page":1})',
-          'Fuzzy:1',
-          'Post:1',
-        ])
-        client.deleteCache(
-          { typename: 'Post' },
-          {
-            callback: () => {
-              haveProps(client.cache.extract(), ['ROOT_QUERY.fuzzy', 'Fuzzy:1'])
-              notHaveProps(client.cache.extract(), [
-                'ROOT_QUERY.getPosts({"page":1})',
-                'Post:1',
-              ])
-              done()
-            },
-          }
-        )
-      })
+        }
+      `,
+    })
+    haveProps(client.cache.extract(), [
+      'ROOT_QUERY.nested',
+      'Nested:1',
+      'User:1',
+      'User:2',
+      'Post:1',
+      'Post:2',
+      'Fuzzy:1',
+    ])
+    client.deleteCache({ typename: 'Post' })
+    haveProps(client.cache.extract(), ['Fuzzy:1'])
+    notHaveProps(client.cache.extract(), [
+      'ROOT_QUERY.nested',
+      'Nested:1',
+      'User:1',
+      'User:2',
+      'Post:1',
+      'Post:2',
+    ])
   })
 
-  it('handle nested value', done => {
-    client
-      .query({
-        query: gql`
-          query {
-            nested {
-              id
-              users {
-                id
-                posts {
-                  id
-                  title
-                }
-              }
-              posts {
-                id
-                title
-              }
-              fuzzy {
-                id
-                posts
-                content
-              }
-            }
+  it('can delete entity without id', async () => {
+    await client.query({
+      query: gql`
+        query {
+          noId {
+            # id
+            content
           }
-        `,
-      })
-      .then(() => {
-        haveProps(client.cache.extract(), [
-          'ROOT_QUERY.nested',
-          'Nested:1',
-          'User:1',
-          'User:2',
-          'Post:1',
-          'Post:2',
-          'Fuzzy:1',
-        ])
-        client.deleteCache(
-          { typename: 'Post' },
-          {
-            callback: () => {
-              haveProps(client.cache.extract(), ['Fuzzy:1'])
-              notHaveProps(client.cache.extract(), [
-                'ROOT_QUERY.nested',
-                'Nested:1',
-                'User:1',
-                'User:2',
-                'Post:1',
-                'Post:2',
-              ])
-              done()
-            },
-          }
-        )
-      })
+        }
+      `,
+    })
+    expect(client.cache.extract()).to.have.property('$ROOT_QUERY.noId')
+    haveProps(client.cache.extract(), ['ROOT_QUERY.noId'])
+    client.deleteCache({ typename: 'NoId' })
+    expect(client.cache.extract()).to.not.have.property('$ROOT_QUERY.noId')
+    notHaveProps(client.cache.extract(), ['ROOT_QUERY.noId'])
   })
 
-  it('can delete entity without id', done => {
-    client
-      .query({
-        query: gql`
-          query {
-            noId {
-              # id
-              content
-            }
-          }
-        `,
-      })
-      .then(() => {
-        expect(client.cache.extract()).to.have.property('$ROOT_QUERY.noId')
-        haveProps(client.cache.extract(), ['ROOT_QUERY.noId'])
-        client.deleteCache(
-          { typename: 'NoId' },
-          {
-            callback: () => {
-              expect(client.cache.extract()).to.not.have.property(
-                '$ROOT_QUERY.noId'
-              )
-              notHaveProps(client.cache.extract(), ['ROOT_QUERY.noId'])
-              done()
-            },
-          }
-        )
-      })
-  })
-
-  it('can delete query directly',  done => {
-     client.query({
+  it('can delete query directly', async () => {
+    await client.query({
       query: gql`
         query {
           pureText
         }
       `,
-    }).then(() => {
-      haveProps(client.cache.extract(), ['ROOT_QUERY.pureText'])
-      client.deleteCache(
-        { query: 'pureText' },
-        {
-          callback: () => {
-            expect(client.cache.extract()).to.not.have.property(
-              'ROOT_QUERY.pureText'
-            )
-            done()
-          },
-        }
-      )
     })
+    haveProps(client.cache.extract(), ['ROOT_QUERY.pureText'])
+    client.deleteCache({ query: 'pureText' })
+    expect(client.cache.extract()).to.not.have.property('ROOT_QUERY.pureText')
   })
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "downlevelIteration": true
   },
   "compileOnSave": true,
-  "exclude": ["test", "typings"]
+  "exclude": ["test", "typings", "benchmark"]
 }


### PR DESCRIPTION
### 主要的优化点

主要是先递归遍历 cache 得到一个 topKeyIdMap ，topKeyIdMap 里只记录 ids.size 大于 0 的，topKeyIdMap.keys() 会比 cache.keys() 少一些，后续可以减少一些遍历。假设 topKeyIdMap 比 cache 的 keys 少 100，然后 deleteTopKeys 假设长度是 N，可以少 N * 100 次。

```
function createTopKeyIdMap(
  obj: NormalizedCacheObject | StoreObject
): Map<string, Set<string>> {
  const idMap = new Map<string, Set<string>>()

  for (const key in obj) {
    const ids = new Set<string>()
    extractIds(obj[key], ids)

    if (ids.size) idMap.set(key, ids)
  }

  return idMap
}
```

后续遍历 deletedTopKeys 和 topKeyIdMap 时，通过 topKey 对应的 idSet 判断是否将 topKey 加入 deletedKeys。这里减少了原先 checkValueFromAnyObject 函数的那一层时间复杂度。

然后加了很多 checkedKeys 类似的 sets，提前检查，避免没有必要的重复的遍历。

### 其他调整

1. 通过 benchmark 发现耗时已经有比较大的降低，分批处理可能意义也不是很大。加上之前自己 setTimeout 、callback 的代码里有些问题，会产生内存泄漏。所以移除相关代码。单测也进行了还原。

### benchmark 比较

改进前

![截屏2024-07-24 11 39 58](https://github.com/user-attachments/assets/8f71f26b-3317-4127-ba38-6d3c397cf693)

改进后

![截屏2024-07-24 11 30 52](https://github.com/user-attachments/assets/69ee8e03-6a8f-4094-a635-e1c7f522b446)



